### PR TITLE
Update deprecated Buffer methods

### DIFF
--- a/src/cli/providers/azureARM/context/functions.ts
+++ b/src/cli/providers/azureARM/context/functions.ts
@@ -143,11 +143,11 @@ export const persistFunction = (context) => {
     const basePath = join(context.projectFolder, functionResource.name)
 
     for (const file in functionResource.properties.files) {
-        writeFile(join(basePath, file), new Buffer(functionResource.properties.files[file], 'utf8'), deploymentFolder)
+        writeFile(join(basePath, file), Buffer.from(functionResource.properties.files[file], 'utf8'), deploymentFolder)
     }
 
     const bindings = JSON.stringify(functionResource.properties.config, null, 4)
-    writeFile(join(basePath, 'function.json'), new Buffer(bindings, 'utf8'), deploymentFolder)
+    writeFile(join(basePath, 'function.json'), Buffer.from(bindings, 'utf8'), deploymentFolder)
 
     const idx = site.resources.indexOf(functionResource)
     site.resources.splice(idx, 1)

--- a/src/cli/providers/azureARM/context/init.ts
+++ b/src/cli/providers/azureARM/context/init.ts
@@ -180,5 +180,5 @@ export const addEnvironmentSetting = (name, value, site) => {
 export const persistHostJson = async (context) => {
     const { deploymentFolder } = context
     const host = JSON.stringify(context.ARMHost, null, 4)
-    writeFile(join(`${context.projectName || 'functionly'}-${context.stage}`, 'host.json'), new Buffer(host, 'utf8'), deploymentFolder)
+    writeFile(join(`${context.projectName || 'functionly'}-${context.stage}`, 'host.json'), Buffer.from(host, 'utf8'), deploymentFolder)
 }

--- a/src/cli/providers/azureARM/index.ts
+++ b/src/cli/providers/azureARM/index.ts
@@ -56,5 +56,5 @@ export const azure = {
 export const persistFile = async (context) => {
     const fileName = projectConfig.name ? `${projectConfig.name}.template.json` : 'azurearm.template.json'
     const templateData = JSON.stringify(context.ARMTemplate, null, 2);
-    writeFile(fileName, new Buffer(templateData, 'binary'))
+    writeFile(fileName, Buffer.from(templateData, 'binary'))
 }

--- a/src/cli/providers/cloudFormation/context/uploadTemplate.ts
+++ b/src/cli/providers/cloudFormation/context/uploadTemplate.ts
@@ -6,7 +6,7 @@ import { projectConfig } from '../../../project/config'
 export const persistCreateTemplate = ExecuteStep.register('PersistCreateTemplate', async (context) => {
     const templateData = JSON.stringify(context.CloudFormationTemplate, null, 2);
     const fileName = projectConfig.name ? `${projectConfig.name}.create.template.json` : 'cloudformation.create.template.json'
-    writeFile(fileName, new Buffer(templateData, 'binary'))
+    writeFile(fileName, Buffer.from(templateData, 'binary'))
 })
 
 export const uploadTemplate = ExecuteStep.register('UploadTemplate', async (context) => {

--- a/src/cli/utilities/aws/s3Upload.ts
+++ b/src/cli/utilities/aws/s3Upload.ts
@@ -43,7 +43,7 @@ export const uploadToAws = ExecuteStep.register('S3-Upload', async (context) => 
     return new Promise<any>((resolve, reject) => {
         const version = context.version ? `${context.version}/` : ''
         const folderPah = context.version ? `${context.version}/${context.date.toISOString()}` : `${context.date.toISOString()}`
-        const binary = new Buffer(context.upload.data, 'binary')
+        const binary = Buffer.from(context.upload.data, 'binary')
         let params = {
             ...config.S3,
             Bucket: context.awsBucket,


### PR DESCRIPTION
The Buffer() and new Buffer() constructors are not recommended for use due to security and usability concerns. Please use the new Buffer.alloc(), Buffer.allocUnsafe(), or Buffer.from() construction methods instead.